### PR TITLE
Shuffling around service report service

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,13 @@ If you want to try it out, install it directly from [the github releases tab as 
 
 ```sh
 # osx 64bit
-cf install-plugin -f https://github.com/aegershman/cf-reverse-service-lookup-plugin/releases/download/0.5.1/cf-reverse-service-lookup-plugin-darwin
+cf install-plugin -f https://github.com/aegershman/cf-reverse-service-lookup-plugin/releases/download/0.5.2/cf-reverse-service-lookup-plugin-darwin
 
 # linux 64bit (32bit and ARM6 also available)
-cf install-plugin -f https://github.com/aegershman/cf-reverse-service-lookup-plugin/releases/download/0.5.1/cf-reverse-service-lookup-plugin-amd64
+cf install-plugin -f https://github.com/aegershman/cf-reverse-service-lookup-plugin/releases/download/0.5.2/cf-reverse-service-lookup-plugin-amd64
 
 # windows 64bit (32bit also available)
-cf install-plugin -f https://github.com/aegershman/cf-reverse-service-lookup-plugin/releases/download/0.5.1/cf-reverse-service-lookup-plugin-windows-amd64.exe
+cf install-plugin -f https://github.com/aegershman/cf-reverse-service-lookup-plugin/releases/download/0.5.2/cf-reverse-service-lookup-plugin-windows-amd64.exe
 ```
 
 ## feedback welcome

--- a/cmd/rsl/main.go
+++ b/cmd/rsl/main.go
@@ -77,25 +77,9 @@ func (cmd *reverseServiceLookupCmd) reverseServiceLookupCommand(cli plugin.CliCo
 	for _, service := range serviceGUIDFlag.guids {
 		trimmedServiceGUID := strings.TrimPrefix(service, trimPrefixFlag)
 
-		serviceInstance, err := cf.Services.GetServiceInstanceByGUID(trimmedServiceGUID)
+		serviceReport, err := cf.ServiceReportService.GetServiceReportFromServiceGUID(trimmedServiceGUID)
 		if err != nil {
 			log.Fatalln(err)
-		}
-
-		serviceSpace, err := cf.Spaces.GetSpaceByGUID(serviceInstance.SpaceGUID)
-		if err != nil {
-			log.Fatalln(err)
-		}
-
-		serviceOrganization, err := cf.Orgs.GetOrganizationByGUID(serviceSpace.OrganizationGUID)
-		if err != nil {
-			log.Fatalln(err)
-		}
-
-		serviceReport := v2client.ServiceReport{
-			Service:      serviceInstance,
-			Space:        serviceSpace,
-			Organization: serviceOrganization,
 		}
 
 		serviceReports = append(serviceReports, serviceReport)
@@ -116,7 +100,7 @@ func (cmd *reverseServiceLookupCmd) GetMetadata() plugin.PluginMetadata {
 		Version: plugin.VersionType{
 			Major: 0,
 			Minor: 5,
-			Build: 1,
+			Build: 2,
 		},
 		Commands: []plugin.Command{
 			{

--- a/cmd/rsl/main.go
+++ b/cmd/rsl/main.go
@@ -79,7 +79,7 @@ func (cmd *reverseServiceLookupCmd) reverseServiceLookupCommand(cli plugin.CliCo
 		trimmedServiceGUIDs = append(trimmedServiceGUIDs, trimmedServiceGUID)
 	}
 
-	serviceReports, err := cf.Lookup(trimmedServiceGUIDs...)
+	serviceReports, err := cf.ServiceReportService.GetServiceReportsFromServiceGUIDs(trimmedServiceGUIDs...)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/cmd/rsl/main.go
+++ b/cmd/rsl/main.go
@@ -73,16 +73,15 @@ func (cmd *reverseServiceLookupCmd) reverseServiceLookupCommand(cli plugin.CliCo
 		log.Fatalln(err)
 	}
 
-	var serviceReports []v2client.ServiceReport
+	var trimmedServiceGUIDs []string
 	for _, service := range serviceGUIDFlag.guids {
 		trimmedServiceGUID := strings.TrimPrefix(service, trimPrefixFlag)
+		trimmedServiceGUIDs = append(trimmedServiceGUIDs, trimmedServiceGUID)
+	}
 
-		serviceReport, err := cf.ServiceReportService.GetServiceReportFromServiceGUID(trimmedServiceGUID)
-		if err != nil {
-			log.Fatalln(err)
-		}
-
-		serviceReports = append(serviceReports, serviceReport)
+	serviceReports, err := cf.Lookup(trimmedServiceGUIDs...)
+	if err != nil {
+		log.Fatalln(err)
 	}
 
 	presenter := v2client.Presenter{

--- a/internal/v2client/client.go
+++ b/internal/v2client/client.go
@@ -12,9 +12,10 @@ type Client struct {
 	cfc    cfclient.CloudFoundryClient
 	common service
 
-	Orgs     *OrgsService
-	Services *ServicesService
-	Spaces   *SpacesService
+	Orgs                 *OrgsService
+	ServiceReportService *ServiceReportService
+	Services             *ServicesService
+	Spaces               *SpacesService
 }
 
 // NewClient -
@@ -45,6 +46,7 @@ func NewClient(cli plugin.CliConnection) (*Client, error) {
 	c.cfc = cfc
 	c.common.client = c
 	c.Orgs = (*OrgsService)(&c.common)
+	c.ServiceReportService = (*ServiceReportService)(&c.common)
 	c.Services = (*ServicesService)(&c.common)
 	c.Spaces = (*SpacesService)(&c.common)
 	return c, nil

--- a/internal/v2client/client.go
+++ b/internal/v2client/client.go
@@ -55,18 +55,3 @@ func NewClient(cli plugin.CliConnection) (*Client, error) {
 	c.Spaces = (*SpacesService)(&c.common)
 	return c, nil
 }
-
-// Lookup -
-func (c *Client) Lookup(serviceGUIDs ...string) ([]ServiceReport, error) {
-	var serviceReports []ServiceReport
-	for _, serviceGUID := range serviceGUIDs {
-		serviceReport, err := c.ServiceReportService.GetServiceReportFromServiceGUID(serviceGUID)
-		if err != nil {
-			return nil, err
-		}
-		serviceReports = append(serviceReports, serviceReport)
-	}
-
-	return serviceReports, nil
-
-}

--- a/internal/v2client/client.go
+++ b/internal/v2client/client.go
@@ -55,3 +55,18 @@ func NewClient(cli plugin.CliConnection) (*Client, error) {
 	c.Spaces = (*SpacesService)(&c.common)
 	return c, nil
 }
+
+// Lookup -
+func (c *Client) Lookup(serviceGUIDs ...string) ([]ServiceReport, error) {
+	var serviceReports []ServiceReport
+	for _, serviceGUID := range serviceGUIDs {
+		serviceReport, err := c.ServiceReportService.GetServiceReportFromServiceGUID(serviceGUID)
+		if err != nil {
+			return nil, err
+		}
+		serviceReports = append(serviceReports, serviceReport)
+	}
+
+	return serviceReports, nil
+
+}

--- a/internal/v2client/client.go
+++ b/internal/v2client/client.go
@@ -7,6 +7,10 @@ import (
 	"github.com/cloudfoundry/cli/plugin"
 )
 
+type service struct {
+	client *Client
+}
+
 // Client -
 type Client struct {
 	cfc    cfclient.CloudFoundryClient
@@ -50,8 +54,4 @@ func NewClient(cli plugin.CliConnection) (*Client, error) {
 	c.Services = (*ServicesService)(&c.common)
 	c.Spaces = (*SpacesService)(&c.common)
 	return c, nil
-}
-
-type service struct {
-	client *Client
 }

--- a/internal/v2client/service_report.go
+++ b/internal/v2client/service_report.go
@@ -10,6 +10,19 @@ type ServiceReport struct {
 // ServiceReportService -
 type ServiceReportService service
 
+// GetServiceReportsFromServiceGUIDs -
+func (s *ServiceReportService) GetServiceReportsFromServiceGUIDs(serviceGUIDs ...string) ([]ServiceReport, error) {
+	var serviceReports []ServiceReport
+	for _, serviceGUID := range serviceGUIDs {
+		serviceReport, err := s.client.ServiceReportService.GetServiceReportFromServiceGUID(serviceGUID)
+		if err != nil {
+			return nil, err
+		}
+		serviceReports = append(serviceReports, serviceReport)
+	}
+	return serviceReports, nil
+}
+
 // GetServiceReportFromServiceGUID -
 func (s *ServiceReportService) GetServiceReportFromServiceGUID(serviceGUID string) (ServiceReport, error) {
 	serviceInstance, err := s.client.Services.GetServiceInstanceByGUID(serviceGUID)

--- a/internal/v2client/service_report.go
+++ b/internal/v2client/service_report.go
@@ -6,3 +6,31 @@ type ServiceReport struct {
 	Service      `json:"service"`
 	Space        `json:"space"`
 }
+
+// ServiceReportService -
+type ServiceReportService service
+
+// GetServiceReportFromServiceGUID -
+func (s *ServiceReportService) GetServiceReportFromServiceGUID(serviceGUID string) (ServiceReport, error) {
+	serviceInstance, err := s.client.Services.GetServiceInstanceByGUID(serviceGUID)
+	if err != nil {
+		return ServiceReport{}, err
+	}
+
+	serviceSpace, err := s.client.Spaces.GetSpaceByGUID(serviceInstance.SpaceGUID)
+	if err != nil {
+		return ServiceReport{}, err
+	}
+
+	serviceOrganization, err := s.client.Orgs.GetOrganizationByGUID(serviceSpace.OrganizationGUID)
+	if err != nil {
+		return ServiceReport{}, err
+	}
+
+	return ServiceReport{
+		Service:      serviceInstance,
+		Space:        serviceSpace,
+		Organization: serviceOrganization,
+	}, nil
+
+}


### PR DESCRIPTION
Moves the calculation & aggregation of service reports into a service which... well, performs service reporting. We call it "service report service" (I know. Gorgeous naming.)

Wanting to split this out a bit in order to tee up doing requests in parallel, and for different "kinds" of reports, like "apps" or "orgs", etc.