### PR TITLE
Remove logrus

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,13 @@ If you want to try it out, install it directly from [the github releases tab as 
 
 ```sh
 # osx 64bit
-cf install-plugin -f https://github.com/aegershman/cf-reverse-service-lookup-plugin/releases/download/0.5.5/cf-reverse-service-lookup-plugin-darwin
+cf install-plugin -f https://github.com/aegershman/cf-reverse-service-lookup-plugin/releases/download/0.6.0/cf-reverse-service-lookup-plugin-darwin
 
 # linux 64bit (32bit and ARM6 also available)
-cf install-plugin -f https://github.com/aegershman/cf-reverse-service-lookup-plugin/releases/download/0.5.5/cf-reverse-service-lookup-plugin-amd64
+cf install-plugin -f https://github.com/aegershman/cf-reverse-service-lookup-plugin/releases/download/0.6.0/cf-reverse-service-lookup-plugin-amd64
 
 # windows 64bit (32bit also available)
-cf install-plugin -f https://github.com/aegershman/cf-reverse-service-lookup-plugin/releases/download/0.5.5/cf-reverse-service-lookup-plugin-windows-amd64.exe
+cf install-plugin -f https://github.com/aegershman/cf-reverse-service-lookup-plugin/releases/download/0.6.0/cf-reverse-service-lookup-plugin-windows-amd64.exe
 ```
 
 ## updating and releasing
@@ -83,7 +83,7 @@ cf install-plugin -f https://github.com/aegershman/cf-reverse-service-lookup-plu
 - `go mod tidy`
 - update the plugin version in `main.go`
 - update the `README` install-plugin section to reference the new upcoming release version
-- `git tag 0.5.5` -- or whatever version, of course
+- `git tag 0.6.0` -- or whatever version, of course
 - `git push origin --tags`
 - `export GITHUB_TOKEN="xyzabc"`
 - `goreleaser release`

--- a/cmd/rsl/main.go
+++ b/cmd/rsl/main.go
@@ -3,12 +3,12 @@ package main
 import (
 	"flag"
 	"fmt"
+	"log"
 	"os"
 	"strings"
 
 	"code.cloudfoundry.org/cli/plugin"
 	"github.com/aegershman/cf-reverse-service-lookup-plugin/internal/v2client"
-	log "github.com/sirupsen/logrus"
 )
 
 type reverseServiceLookupCmd struct{}
@@ -43,14 +43,12 @@ func (f *formatFlag) Set(value string) error {
 func (cmd *reverseServiceLookupCmd) reverseServiceLookupCommand(cli plugin.CliConnection, args []string) {
 	var (
 		formatFlag      formatFlag
-		logLevelFlag    string
 		serviceGUIDFlag serviceGUIDFlag
 		trimPrefixFlag  string
 	)
 
 	flagss := flag.NewFlagSet(args[0], flag.ContinueOnError)
 	flagss.Var(&formatFlag, "format", "")
-	flagss.StringVar(&logLevelFlag, "log-level", "info", "")
 	flagss.Var(&serviceGUIDFlag, "s", "")
 	flagss.StringVar(&trimPrefixFlag, "trim-prefix", "service-instance_", "")
 
@@ -62,12 +60,6 @@ func (cmd *reverseServiceLookupCmd) reverseServiceLookupCommand(cli plugin.CliCo
 	if len(serviceGUIDFlag.guids) == 0 {
 		log.Fatalln("please provide at least one -s service-instance_GUID")
 	}
-
-	logLevel, err := log.ParseLevel(logLevelFlag)
-	if err != nil {
-		log.Fatalln(err)
-	}
-	log.SetLevel(logLevel)
 
 	cf, err := v2client.NewClient(cli)
 	if err != nil {
@@ -106,7 +98,6 @@ func (cmd *reverseServiceLookupCmd) GetMetadata() plugin.PluginMetadata {
 					Usage: "cf rsl [-s service_instance-xyzabc...]",
 					Options: map[string]string{
 						"format":      "format to present (options: table,json) (default: table)",
-						"log-level":   "(options: info,debug,trace) (default: info)",
 						"s":           "service_instance-GUID to look up. Can be of form 'service_instance-xyzguid123' or just 'xyzguid123'",
 						"trim-prefix": "if your services are prefixed with something besides BOSH defaults, change this to be the string prefix before the service GUID... also, if you have that use-case, definitely let me know, I'm intrigued. (default: service_instance-)",
 					},
@@ -122,7 +113,6 @@ func (cmd *reverseServiceLookupCmd) Run(cli plugin.CliConnection, args []string)
 	case "rsl":
 		cmd.reverseServiceLookupCommand(cli, args)
 	default:
-		log.Debugln("did you know plugin commands can still get ran when uninstalling a plugin? interesting, right?")
 		return
 	}
 }

--- a/cmd/rsl/main.go
+++ b/cmd/rsl/main.go
@@ -87,8 +87,8 @@ func (cmd *reverseServiceLookupCmd) GetMetadata() plugin.PluginMetadata {
 		Name: "cf-reverse-service-lookup-plugin",
 		Version: plugin.VersionType{
 			Major: 0,
-			Minor: 5,
-			Build: 5,
+			Minor: 6,
+			Build: 0,
 		},
 		Commands: []plugin.Command{
 			{

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aegershman/cf-reverse-service-lookup-plugin
 go 1.15
 
 require (
-	code.cloudfoundry.org/cli v6.53.0+incompatible
+	code.cloudfoundry.org/cli v7.1.0+incompatible
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/cloudfoundry-community/go-cfclient v0.0.0-20201023184446-5cf5e1c3862d
 	github.com/google/go-cmp v0.4.1 // indirect
@@ -15,7 +15,6 @@ require (
 	github.com/onsi/ginkgo v1.12.3 // indirect
 	github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/sirupsen/logrus v1.7.0
 	github.com/smartystreets/assertions v1.1.0 // indirect
 	github.com/smartystreets/goconvey v1.6.4 // indirect
 	github.com/stretchr/testify v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
-code.cloudfoundry.org/cli v6.53.0+incompatible h1:H5PUIvC9686VS0ZwdsJiFa+EzbK3RNAVTkUa2bvhUjI=
-code.cloudfoundry.org/cli v6.53.0+incompatible/go.mod h1:e4d+EpbwevNhyTZKybrLlyTvpH+W22vMsmdmcTxs/Fo=
+code.cloudfoundry.org/cli v7.1.0+incompatible h1:1Zn3I+epQBaBvnZAaTudCQQ0WdqcWtjtjEV9MBZP08Y=
+code.cloudfoundry.org/cli v7.1.0+incompatible/go.mod h1:e4d+EpbwevNhyTZKybrLlyTvpH+W22vMsmdmcTxs/Fo=
 code.cloudfoundry.org/gofileutils v0.0.0-20170111115228-4d0c80011a0f h1:UrKzEwTgeiff9vxdrfdqxibzpWjxLnuXDI5m6z3GJAk=
 code.cloudfoundry.org/gofileutils v0.0.0-20170111115228-4d0c80011a0f/go.mod h1:sk5LnIjB/nIEU7yP5sDQExVm62wu0pBh3yrElngUisI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -16,9 +16,8 @@ github.com/cloudfoundry-community/go-cfclient v0.0.0-20201023184446-5cf5e1c3862d
 github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0 h1:sDMmm+q/3+BukdIpxwO365v/Rbspp2Nt5XntgQRXq8Q=
 github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0/go.mod h1:4Zcjuz89kmFXt9morQgcfYZAYZ5n8WHjt81YYWIwtTM=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
@@ -95,8 +94,6 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=
-github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v1.1.0 h1:MkTeG1DMwsrdH7QtLXy5W+fUxWq+vmb6cLmyJ7aRtF0=
@@ -106,8 +103,6 @@ github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:s
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
-github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.6.0 h1:jlIyCplCJFULU/01vCkhKuTyc3OorI3bJFuw6obfgho=
 github.com/stretchr/testify v1.6.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -143,7 +138,6 @@ golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/v2client/presenter.go
+++ b/internal/v2client/presenter.go
@@ -3,8 +3,7 @@ package v2client
 import (
 	"encoding/json"
 	"io"
-
-	log "github.com/sirupsen/logrus"
+	"log"
 
 	"github.com/olekukonko/tablewriter"
 )
@@ -37,8 +36,6 @@ func (p *Presenter) Render() {
 			p.asTable()
 		case "json":
 			p.asJSON()
-		default:
-			log.Debugf("unknown format [%s], using default\n", f)
 		}
 	}
 }
@@ -67,7 +64,7 @@ func (p *Presenter) asTable() {
 func (p *Presenter) asJSON() {
 	j, err := json.Marshal(p.serviceReports)
 	if err != nil {
-		log.Debugln(err)
+		log.Fatalln(err)
 	}
 	p.writer.Write(j)
 }


### PR DESCRIPTION
PR which closes https://github.com/aegershman/cf-reverse-service-lookup-plugin/issues/26

As the title implies: eh, let's just bail on logrus altogether. It was included at the time because I wanted a little more experience with gomod and logging in general, but to be honest, we don't need it